### PR TITLE
add function(set_parameters) for logistic_reg

### DIFF
--- a/src/learning/logistic_reg.rs
+++ b/src/learning/logistic_reg.rs
@@ -91,6 +91,11 @@ impl<A: OptimAlgorithm<BaseLogisticRegressor>> LogisticRegressor<A> {
     pub fn parameters(&self) -> Option<&Vector<f64>> {
         self.base.parameters()
     }
+
+    // Set the parameters
+    pub fn set_parameters(&mut self, params: Vector<f64>) {
+        self.base.parameters = Some(params);
+    }
 }
 
 impl<A> SupModel<Matrix<f64>, Vector<f64>> for LogisticRegressor<A>

--- a/src/learning/logistic_reg.rs
+++ b/src/learning/logistic_reg.rs
@@ -92,7 +92,7 @@ impl<A: OptimAlgorithm<BaseLogisticRegressor>> LogisticRegressor<A> {
         self.base.parameters()
     }
 
-    // Set the parameters
+    /// Set the parameters
     pub fn set_parameters(&mut self, params: Vector<f64>) {
         self.base.parameters = Some(params);
     }


### PR DESCRIPTION
In order to support the mesatee export logistic_reg training model file and the prediction based on the model file, i add a function(set_parameters) for setting the logistic_reg struct 